### PR TITLE
Expose `into_can_id` in Id struct

### DIFF
--- a/src/frame/id.rs
+++ b/src/frame/id.rs
@@ -18,7 +18,7 @@ impl Id {
         }
     }
 
-    pub(crate) fn into_can_id(self) -> u32 {
+    pub fn into_can_id(self) -> u32 {
         match self {
             Self::Standard(id) => {
                 assert!(id <= sys::CAN_SFF_MASK);


### PR DESCRIPTION
This is useful to know and instead of writing

    let id = match incoming.id { Id::Standard(id) | Id::Extended(id) => id }

I would like to call 

    let id = incoming.id.into_can_id()

(IMHO it would be better to name it `id` instead, but that's ok for me).

That the `from_can_id` function isn't exposed it good, because I'd like to be explicit about which ID format I'd like to use.