### PR TITLE
Remove deprecation

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 env:
+  BINDGEN_EXTRA_CLANG_ARGS: -Ican-utils/include
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -21,6 +22,7 @@ jobs:
         - maximum
     steps:
     - uses: actions/checkout@v2
+    - run: git clone --depth 1 https://github.com/linux-can/can-utils.git
     - if: matrix.dependency-versions == 'minimal'
       run: |
         rustup toolchain add nightly
@@ -32,5 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: git clone --depth 1 https://github.com/linux-can/can-utils.git
     - run: cargo fmt --verbose -- --check
     - run: cargo clippy --all-targets --all-features

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -6,7 +6,6 @@ on:
   pull_request:
 
 env:
-  BINDGEN_EXTRA_CLANG_ARGS: -Ican-utils/include
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -17,12 +16,17 @@ jobs:
         target:
         - x86_64-unknown-linux-gnu
         - x86_64-unknown-linux-musl
+        header:
+        - v2020.11.0
+        - v2020.12.0
         dependency-versions:
         - minimal
         - maximum
+    env:
+      BINDGEN_EXTRA_CLANG_ARGS: -Ican-utils/include
     steps:
     - uses: actions/checkout@v2
-    - run: git clone --depth 1 https://github.com/linux-can/can-utils.git
+    - run: git clone https://github.com/linux-can/can-utils.git --branch ${{ matrix.header }} --depth 1
     - if: matrix.dependency-versions == 'minimal'
       run: |
         rustup toolchain add nightly
@@ -34,6 +38,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: git clone --depth 1 https://github.com/linux-can/can-utils.git
     - run: cargo fmt --verbose -- --check
     - run: cargo clippy --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 
 [features]
 aio = ["tokio"]
+can-dlc-unaliased = []
 
 [dependencies]
 bitflags = "1.2"

--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -15,7 +15,7 @@ impl DataFrame {
         let mut inner = MaybeUninit::<sys::can_frame>::zeroed();
         unsafe {
             (*inner.as_mut_ptr()).can_id = id.into_can_id();
-            (*inner.as_mut_ptr()).can_dlc = data.len() as _;
+            *sys::can_frame_len_mut(inner.as_mut_ptr()) = data.len() as _;
             (*inner.as_mut_ptr()).data[..data.len()].copy_from_slice(data);
             Self(inner.assume_init())
         }
@@ -26,7 +26,8 @@ impl DataFrame {
     }
 
     pub fn data(&self) -> &[u8] {
-        &self.0.data[..self.0.can_dlc as _]
+        // SAFETY: call is safe, because &self.0 points to a valid reference
+        &self.0.data[..unsafe { sys::can_frame_len(&self.0) } as _]
     }
 }
 

--- a/src/frame/remote.rs
+++ b/src/frame/remote.rs
@@ -15,7 +15,7 @@ impl RemoteFrame {
         let mut inner = MaybeUninit::<sys::can_frame>::zeroed();
         unsafe {
             (*inner.as_mut_ptr()).can_id = id.into_can_id();
-            (*inner.as_mut_ptr()).can_dlc = dlc;
+            *sys::can_frame_len_mut(inner.as_mut_ptr()) = dlc;
             Self(inner.assume_init())
         }
     }
@@ -25,7 +25,8 @@ impl RemoteFrame {
     }
 
     pub fn dlc(&self) -> u8 {
-        self.0.can_dlc
+        // SAFETY: call is safe, because &self.0 points to a valid reference
+        unsafe { sys::can_frame_len(&self.0) }
     }
 }
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -5,3 +5,27 @@
 #![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+pub unsafe fn can_frame_len(frame: *const can_frame) -> u8 {
+    #[cfg(feature = "can-dlc-unaliased")]
+    {
+        (*frame).can_dlc
+    }
+
+    #[cfg(not(feature = "can-dlc-unaliased"))]
+    {
+        (*frame).__bindgen_anon_1.len
+    }
+}
+
+pub unsafe fn can_frame_len_mut(frame: *mut can_frame) -> *mut u8 {
+    #[cfg(feature = "can-dlc-unaliased")]
+    {
+        &mut (*frame).can_dlc
+    }
+
+    #[cfg(not(feature = "can-dlc-unaliased"))]
+    {
+        &mut (*frame).__bindgen_anon_1.len
+    }
+}


### PR DESCRIPTION
according to linux-can/can-utils@c398e56 the `can_dlc` field is deprected now and `len` should be used instead.

Fixes #29 